### PR TITLE
make log dir configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_synapse_dh_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_nam
 matrix_synapse_baseurl: "https://{{ matrix_server_name }}"
 matrix_synapse_signing_key_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_name }}.signing.key"
 matrix_synapse_version: "v0.99.2"
+matrix_synapse_log_dir: "/var/log/matrix_synapse"
 matrix_synapse_log_days_keep: 30
 matrix_synapse_skip_tls: false
 matrix_synapse_pid_file: "{{ matrix_synapse_base_path }}/synapse.pid"

--- a/files/matrix_synapse.conf
+++ b/files/matrix_synapse.conf
@@ -1,2 +1,0 @@
-if $programname == 'matrix_synapse' then /var/log/matrix_synapse/matrix_synapse.log
-if $programname == 'matrix_synapse' then ~

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -1,14 +1,14 @@
 ---
 - name: create logging folder
   file:
-    name: /var/log/synapse/
+    name: "{{ matrix_synapse_log_dir }}"
     state: directory
     owner: synapse
     group: synapse
 
 - name: copy syslog config
-  copy:
-    src: matrix_synapse.conf
+  template:
+    src: syslog-synapse.conf.j2
     dest: /etc/rsyslog.d/matrix_synapse.conf
     owner: root
   notify: restart rsyslog
@@ -17,6 +17,7 @@
   template:
     src: logrotate.j2
     dest: /etc/logrotate.d/matrix_synapse
+    owner: root
 
 - name: Deploy log config
   copy:

--- a/templates/syslog-synapse.conf.j2
+++ b/templates/syslog-synapse.conf.j2
@@ -1,0 +1,2 @@
+if $programname == 'matrix_synapse' then {{ matrix_synapse_log_dir }}/matrix_synapse.log
+if $programname == 'matrix_synapse' then ~


### PR DESCRIPTION
This additionally fixes an issue where some places used /var/log/synapse and other used /var/log/matrix_synapse, ending up with broken logging. By moving it to a var, we can't accidentally put different values here.