### PR TITLE
Work around an issue with replacing the base image of a container

### DIFF
--- a/tasks/deployment.yml
+++ b/tasks/deployment.yml
@@ -64,6 +64,8 @@
     ports: "{{ matrix_synapse_docker_ports }}"
     labels: "{{ matrix_synapse_docker_labels }}"
     restart_policy: unless-stopped
+    recreate: true
+    pull: true
     entrypoint: "python"
     command:
       - "-m"


### PR DESCRIPTION
The problem being solved here is that the docker_container module does not fully check the state of the containers. If only the image used to create a container changes (while bumping a version for example), the module will report that there are no changes and everything is in the desired state already. This change means we loose idempotency, but that is more desirable than ending up with outdated software IMO. The correct solution here is to fix the docker_container module.